### PR TITLE
Require tmux for server launcher

### DIFF
--- a/Resources/Server/1MB-start.sh
+++ b/Resources/Server/1MB-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @Filename: 1MB-start.sh
-# @Version: 2.17.0, build 073 for Minecraft 26.2 (Java 25, 64bit)
+# @Version: 2.17.1, build 074 for Minecraft 26.2 (Java 25, 64bit)
 # @Release: August 4th, 2026
 # @Description: Helps us start and fork a Minecraft 26.2 server session.
 # @Contact: I am @floris on Twitter, and mrfloris in MineCraft.
@@ -75,22 +75,16 @@ fi
 
 _output debug "Attempting to start your Minecraft '$_serverName' server ... "
 
-if type "tmux" >/dev/null 2>&1; then
-    _output debug "Found 'tmux', attempting to create and fork a new tmux session into background ..."
-    if ! tmux new -d -s "$_serverName" 2>/dev/null; then
-        _output oops "Could not create the '$_serverName' tmux session. It may already exist; check with 'tmux ls'."
-    fi
-    tmux send-keys -t "$_serverName" "./$_sibling" ENTER
-    [[ "$_debug" == true ]] && tmux ls; _output debug "To re-attach: tmux attach -t $_serverName"
-elif type "screen" >/dev/null 2>&1; then
-    _output debug "Could not find 'tmux' (preferred), but found 'screen', attempting to create and fork a new screen session into background ..."
-    screen -dmS "$_serverName" bash "$_sibling"
-    [[ "$_debug" == true ]] && screen -ls; _output debug "To re-attach: screen -r $_serverName"
-else
-    _output debug "Oops, 'tmux' (preferred), nor 'screen' seems to be installed. Try installing either. \\n -> macOS: brew install tmux, Ubuntu: apt install screen \\n -> Can't fork session, trying '$_sibling' directly ..."
-    sleep 4
-    bash "$_sibling" || _output oops "Something is wrong, I could not start your server."
+if ! type "tmux" >/dev/null 2>&1; then
+    _output oops "'tmux' is required but was not found. On macOS, install it with: brew install tmux"
 fi
+
+_output debug "Found 'tmux', attempting to create and fork a new tmux session into background ..."
+if ! tmux new -d -s "$_serverName" 2>/dev/null; then
+    _output oops "Could not create the '$_serverName' tmux session. It may already exist; check with 'tmux ls'."
+fi
+tmux send-keys -t "$_serverName" "./$_sibling" ENTER
+[[ "$_debug" == true ]] && tmux ls; _output debug "To re-attach: tmux attach -t $_serverName"
 
 _output debug "Done."
 

--- a/Resources/Server/1mb-start-todo.md
+++ b/Resources/Server/1mb-start-todo.md
@@ -30,6 +30,15 @@ build `073`.
 No other behavioral modernization item below is included in this narrowly
 scoped fix. The file's missing final newline was normalized mechanically.
 
+## Completed in 2.17.1 build 074
+
+- [x] Removed GNU Screen support. `tmux` is now the wrapper's only detached
+  session backend.
+- [x] Removed the automatic foreground fallback. A missing `tmux` executable
+  now stops the wrapper instead of starting Paper outside a detached session.
+- [x] Added a focused macOS installation hint: `brew install tmux`. Ubuntu
+  installation guidance is intentionally omitted.
+
 ## Critical
 
 - [x] Stop immediately when tmux session creation fails; never send startup
@@ -48,9 +57,8 @@ scoped fix. The file's missing final newline was normalized mechanically.
 - [ ] Fix `_debug=false`: the final debug call currently returns status `1`, so
   an otherwise successful wrapper exits as a failure when debug output is
   disabled.
-- [ ] Remove the implicit GNU Screen fallback, make it explicit opt-in, or add
-  reliable duplicate-session protection and checked startup. Screen permits
-  materially different and potentially duplicate session behavior.
+- [x] Remove the implicit GNU Screen fallback. Completed in `2.17.1`, build
+  `074`; tmux is now required.
 - [ ] Add a per-server-instance lock in `1MB-minecraft.sh` during that script's
   later review. Different tmux names can otherwise launch the same server
   directory twice, and this wrapper cannot protect standalone launches.
@@ -66,8 +74,8 @@ scoped fix. The file's missing final newline was normalized mechanically.
 - [ ] Establish deterministic command discovery for non-login environments.
   Account for Apple Silicon Homebrew (`/opt/homebrew/bin`), Intel Homebrew
   (`/usr/local/bin`), and standard macOS/Ubuntu paths.
-- [ ] Remove the implicit foreground fallback. If tmux is unavailable, fail
-  clearly and let users run `1MB-minecraft.sh` directly for foreground tests.
+- [x] Remove the implicit foreground fallback. Completed in `2.17.1`, build
+  `074`; a missing tmux executable now fails clearly.
 - [ ] Use exact tmux targets such as `-t "=$name"` in scripted checks so prefix
   matching cannot select another session.
 
@@ -81,8 +89,9 @@ scoped fix. The file's missing final newline was normalized mechanically.
   launchd/systemd logs remain clean.
 - [ ] Verify that the sibling is a regular readable and executable file, and
   include its absolute path in errors.
-- [ ] Correct the Ubuntu dependency hint to recommend `apt install tmux` when
-  tmux is the preferred backend.
+- [x] Remove the obsolete Screen and Ubuntu dependency hints. Completed in
+  `2.17.1`, build `074`; the missing-tmux error gives the requested macOS
+  Homebrew command only.
 - [ ] Make the wrapper header independent of Paper and Java versions, because
   RAM, JVM selection, Java version, and Paper arguments belong in
   `1MB-minecraft.sh`.
@@ -124,9 +133,8 @@ scoped fix. The file's missing final newline was normalized mechanically.
 
 ## Compatibility decisions before the next larger revision
 
-1. Confirm whether automatic Screen support may be removed.
-2. Confirm whether the tmux session should disappear when Paper stops.
-3. Confirm whether session names remain letters-only or expand to a documented
+1. Confirm whether the tmux session should disappear when Paper stops.
+2. Confirm whether session names remain letters-only or expand to a documented
    safe character set.
-4. Confirm which quality-of-life commands, if any, belong in this intentionally
+3. Confirm which quality-of-life commands, if any, belong in this intentionally
    small wrapper.


### PR DESCRIPTION
## Summary

- remove GNU Screen support from `1MB-start.sh`
- remove the automatic foreground launch fallback
- require tmux and provide `brew install tmux` when it is missing on macOS
- bump the wrapper to 2.17.1 build 074 and update the modernization TODO

## Why

The server fleet has standardized on tmux. Falling back to Screen or silently
starting Paper in the foreground creates different operational behavior and can
hide a missing or broken tmux installation.

## Impact

The wrapper now exits clearly when tmux is unavailable. Existing tmux startup,
duplicate-session protection, and reattachment behavior remain unchanged.

## Validation

- stock macOS `/bin/bash -n`
- `git diff --check`
- verified the file ends with an LF newline
- missing tmux with a fake Screen available: exits 1 and never invokes Screen
- duplicate tmux session: exits 1 and never calls `send-keys`
- successful tmux creation: calls `send-keys` exactly once and exits 0
- verified no Screen, delay, or foreground fallback remains in the wrapper
