### PR TITLE
Launch server atomically from resolved directory

### DIFF
--- a/Resources/Server/1MB-start.sh
+++ b/Resources/Server/1MB-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @Filename: 1MB-start.sh
-# @Version: 2.17.1, build 074 for Minecraft 26.2 (Java 25, 64bit)
+# @Version: 2.17.2, build 075 for Minecraft 26.2 (Java 25, 64bit)
 # @Release: August 4th, 2026
 # @Description: Helps us start and fork a Minecraft 26.2 server session.
 # @Contact: I am @floris on Twitter, and mrfloris in MineCraft.
@@ -79,11 +79,10 @@ if ! type "tmux" >/dev/null 2>&1; then
     _output oops "'tmux' is required but was not found. On macOS, install it with: brew install tmux"
 fi
 
-_output debug "Found 'tmux', attempting to create and fork a new tmux session into background ..."
-if ! tmux new -d -s "$_serverName" 2>/dev/null; then
-    _output oops "Could not create the '$_serverName' tmux session. It may already exist; check with 'tmux ls'."
+_output debug "Found 'tmux', attempting to start '$_sibling' in a detached tmux session ..."
+if ! tmux new-session -d -s "$_serverName" "exec \"./$_sibling\""; then
+    _output oops "Could not create the '$_serverName' tmux session and start '$_sibling'. Review the tmux error above and check with 'tmux ls'."
 fi
-tmux send-keys -t "$_serverName" "./$_sibling" ENTER
 [[ "$_debug" == true ]] && tmux ls; _output debug "To re-attach: tmux attach -t $_serverName"
 
 _output debug "Done."

--- a/Resources/Server/1MB-start.sh
+++ b/Resources/Server/1MB-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @Filename: 1MB-start.sh
-# @Version: 2.17.2, build 075 for Minecraft 26.2 (Java 25, 64bit)
+# @Version: 2.17.3, build 076 for Minecraft 26.2 (Java 25, 64bit)
 # @Release: August 4th, 2026
 # @Description: Helps us start and fork a Minecraft 26.2 server session.
 # @Contact: I am @floris on Twitter, and mrfloris in MineCraft.
@@ -61,8 +61,48 @@ function _output {
     esac
 }
 
+function _resolveScriptDirectory {
+    local _source="${BASH_SOURCE[0]}"
+    local _sourceDir=""
+    local _linkTarget=""
+    local _linkDepth=0
+
+    case "$_source" in
+    */*)
+        ;;
+    *)
+        if [ -e "$_source" ] || [ -L "$_source" ]; then
+            _source="./$_source"
+        else
+            _source=$(command -v "$_source") || return 1
+        fi
+        ;;
+    esac
+
+    while [ -L "$_source" ]; do
+        _linkDepth=$((_linkDepth + 1))
+        [ "$_linkDepth" -gt 40 ] && return 1
+
+        _sourceDir=$(cd -P -- "$(dirname -- "$_source")" >/dev/null 2>&1 && pwd -P) || return 1
+        _linkTarget=$(readlink "$_source") || return 1
+
+        case "$_linkTarget" in
+        /*) _source="$_linkTarget" ;;
+        *) _source="$_sourceDir/$_linkTarget" ;;
+        esac
+    done
+
+    cd -P -- "$(dirname -- "$_source")" >/dev/null 2>&1 && pwd -P
+}
+
 [ "$EUID" -eq 0 ] && _output oops "*!* This script should not be run using sudo, or as the root user!"
-[ ! -x "$_sibling" ] && _output oops "This '$0' script requires '$_sibling' to work and be executable. Correct the permissions, or download it from https://scripts.1moreblock.com/ "
+
+_scriptDir=$(_resolveScriptDirectory) || _output oops "Could not resolve the server directory containing '$0'."
+_siblingPath="$_scriptDir/$_sibling"
+
+if [ ! -f "$_siblingPath" ] || [ ! -r "$_siblingPath" ] || [ ! -x "$_siblingPath" ]; then
+    _output oops "This '$0' script requires '$_siblingPath' to be a readable and executable file. Correct the permissions, or download it from https://scripts.1moreblock.com/ "
+fi
 
 if [ -n "$1" ]; then
     _input=$(echo "$1" | awk '{ print tolower($1) }'); _input=$(echo "${_input}" | awk '{print substr ($0, 0, 16)}');
@@ -74,13 +114,14 @@ if [ -n "$1" ]; then
 fi
 
 _output debug "Attempting to start your Minecraft '$_serverName' server ... "
+_output debug "Using server directory: $_scriptDir"
 
 if ! type "tmux" >/dev/null 2>&1; then
     _output oops "'tmux' is required but was not found. On macOS, install it with: brew install tmux"
 fi
 
 _output debug "Found 'tmux', attempting to start '$_sibling' in a detached tmux session ..."
-if ! tmux new-session -d -s "$_serverName" "exec \"./$_sibling\""; then
+if ! tmux new-session -d -s "$_serverName" -c "$_scriptDir" "exec \"./$_sibling\""; then
     _output oops "Could not create the '$_serverName' tmux session and start '$_sibling'. Review the tmux error above and check with 'tmux ls'."
 fi
 [[ "$_debug" == true ]] && tmux ls; _output debug "To re-attach: tmux attach -t $_serverName"

--- a/Resources/Server/1mb-start-todo.md
+++ b/Resources/Server/1mb-start-todo.md
@@ -39,6 +39,16 @@ scoped fix. The file's missing final newline was normalized mechanically.
 - [x] Added a focused macOS installation hint: `brew install tmux`. Ubuntu
   installation guidance is intentionally omitted.
 
+## Completed in 2.17.2 build 075
+
+- [x] Replaced the separate `tmux new` and `tmux send-keys` operations with one
+  checked `tmux new-session -d` command that directly executes
+  `1MB-minecraft.sh`.
+- [x] Made the approved lifecycle explicit: the tmux session closes when
+  `1MB-minecraft.sh` exits, so a stopped or crashed server does not leave a
+  stale shell session behind.
+- [x] Stopped suppressing tmux's own session-creation error output.
+
 ## Critical
 
 - [x] Stop immediately when tmux session creation fails; never send startup
@@ -49,11 +59,12 @@ scoped fix. The file's missing final newline was normalized mechanically.
 - [ ] Resolve `1MB-minecraft.sh` relative to the wrapper's own directory, not
   the caller's current working directory. This is required for reliable
   launchd, systemd, SSH, and absolute-path invocation.
-- [ ] Replace the two-stage `tmux new` plus `tmux send-keys` launch with one
+- [x] Replace the two-stage `tmux new` plus `tmux send-keys` launch with one
   checked, atomic `tmux new-session -d` command that starts the sibling
-  directly.
-- [ ] Preserve and report tmux failures accurately. Do not suppress the useful
-  tmux diagnostic or print `Done` after a failed child launch.
+  directly. Completed in `2.17.2`, build `075`.
+- [ ] Detect and report when the child exits immediately after tmux successfully
+  creates the session. The tmux command confirms session creation, not that
+  Paper completed startup.
 - [ ] Fix `_debug=false`: the final debug call currently returns status `1`, so
   an otherwise successful wrapper exits as a failure when debug output is
   disabled.
@@ -68,16 +79,17 @@ scoped fix. The file's missing final newline was normalized mechanically.
 - [ ] Stop splitting and truncating the requested session name before
   validation. Validate the complete input and length, reject invalid or
   overlong names, and reject unexpected extra arguments.
-- [ ] Decide whether the tmux session should close when
-  `1MB-minecraft.sh` exits. Starting the script as the pane's direct process
-  avoids the current stale shell/session after Paper stops.
+- [x] Close the tmux session when `1MB-minecraft.sh` exits. Approved and
+  completed in `2.17.2`, build `075`; the launcher is now the pane's direct
+  process.
 - [ ] Establish deterministic command discovery for non-login environments.
   Account for Apple Silicon Homebrew (`/opt/homebrew/bin`), Intel Homebrew
   (`/usr/local/bin`), and standard macOS/Ubuntu paths.
 - [x] Remove the implicit foreground fallback. Completed in `2.17.1`, build
   `074`; a missing tmux executable now fails clearly.
-- [ ] Use exact tmux targets such as `-t "=$name"` in scripted checks so prefix
-  matching cannot select another session.
+- [x] Remove the scripted tmux target lookup. Completed in `2.17.2`, build
+  `075`; the atomic launch no longer uses `send-keys` against a separate
+  session target.
 
 ## Low priority and cleanup
 
@@ -133,8 +145,7 @@ scoped fix. The file's missing final newline was normalized mechanically.
 
 ## Compatibility decisions before the next larger revision
 
-1. Confirm whether the tmux session should disappear when Paper stops.
-2. Confirm whether session names remain letters-only or expand to a documented
+1. Confirm whether session names remain letters-only or expand to a documented
    safe character set.
-3. Confirm which quality-of-life commands, if any, belong in this intentionally
+2. Confirm which quality-of-life commands, if any, belong in this intentionally
    small wrapper.

--- a/Resources/Server/1mb-start-todo.md
+++ b/Resources/Server/1mb-start-todo.md
@@ -49,6 +49,16 @@ scoped fix. The file's missing final newline was normalized mechanically.
   stale shell session behind.
 - [x] Stopped suppressing tmux's own session-creation error output.
 
+## Completed in 2.17.3 build 076
+
+- [x] Resolve the physical directory containing `1MB-start.sh` instead of
+  relying on the caller's current working directory.
+- [x] Support relative, absolute, PATH-based, and symlinked invocation without
+  depending on GNU-only `readlink -f`, preserving compatibility with macOS and
+  Ubuntu.
+- [x] Give tmux the resolved server directory explicitly with `new-session -c`
+  and validate the sibling through its resolved absolute path.
+
 ## Critical
 
 - [x] Stop immediately when tmux session creation fails; never send startup
@@ -56,9 +66,10 @@ scoped fix. The file's missing final newline was normalized mechanically.
 
 ## High priority
 
-- [ ] Resolve `1MB-minecraft.sh` relative to the wrapper's own directory, not
-  the caller's current working directory. This is required for reliable
-  launchd, systemd, SSH, and absolute-path invocation.
+- [x] Resolve `1MB-minecraft.sh` relative to the wrapper's own directory, not
+  the caller's current working directory. Completed in `2.17.3`, build `076`,
+  including launchd, systemd, SSH, PATH, absolute-path, and symlinked
+  invocation scenarios.
 - [x] Replace the two-stage `tmux new` plus `tmux send-keys` launch with one
   checked, atomic `tmux new-session -d` command that starts the sibling
   directly. Completed in `2.17.2`, build `075`.
@@ -99,8 +110,8 @@ scoped fix. The file's missing final newline was normalized mechanically.
   with status `1`.
 - [ ] Emit ANSI colors only to an interactive terminal and honor `NO_COLOR` so
   launchd/systemd logs remain clean.
-- [ ] Verify that the sibling is a regular readable and executable file, and
-  include its absolute path in errors.
+- [x] Verify that the sibling is a regular readable and executable file, and
+  include its absolute path in errors. Completed in `2.17.3`, build `076`.
 - [x] Remove the obsolete Screen and Ubuntu dependency hints. Completed in
   `2.17.1`, build `074`; the missing-tmux error gives the requested macOS
   Homebrew command only.


### PR DESCRIPTION
## Summary

- start `1MB-minecraft.sh` directly in a single checked `tmux new-session`
  operation
- remove simulated `send-keys` startup and close the tmux session when the
  launcher exits
- resolve the physical server directory for relative, absolute, PATH, and
  symlink invocation
- pass the resolved working directory explicitly through tmux `-c`
- validate the sibling through its absolute path
- bump `1MB-start.sh` through 2.17.3 build 076 and update the modernization TODO

## Why

The old two-stage launch created a shell and then typed the startup command into
it. This left a timing gap, depended on the caller's working directory, and
could leave stale shell sessions after Paper stopped. Starting from launchd,
systemd, SSH, another directory, or a symlink could also resolve Paper files in
the wrong location.

## Impact

The tmux session now directly owns the launcher and closes with it. Paper
receives the directory containing the real wrapper as its working directory,
including when the wrapper is called from elsewhere or through a symlink.
Duplicate-session protection remains atomic and tmux's native errors remain
visible.

## Validation

- stock macOS Bash 3.2 syntax and behavior checks
- `git diff --check` and final-LF verification
- relative, absolute, bare-name, absolute/relative PATH, spaces,
  parent-directory symlink, absolute symlink, relative symlink, and
  chained-symlink invocation tests
- missing sibling fails before tmux and reports its absolute path
- fake tmux verifies `-c` is passed as one argument and no `send-keys` remains
- real tmux 3.7b private-socket test confirms the child PWD, duplicate rejection,
  and session closure
- implementation uses basic `readlink` and `pwd -P`, not GNU-only `readlink -f`,
  for macOS and Ubuntu compatibility
