### PR TITLE
Modernize the tmux server launcher output and controls

### DIFF
--- a/Resources/Server/1MB-start.sh
+++ b/Resources/Server/1MB-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @Filename: 1MB-start.sh
-# @Version: 2.17.4, build 077 for Minecraft 26.2 (Java 25, 64bit)
+# @Version: 2.17.5, build 078 for Minecraft 26.2 (Java 25, 64bit)
 # @Release: August 4th, 2026
 # @Description: Helps us start and fork a Minecraft 26.2 server session.
 # @Contact: I am @floris on Twitter, and mrfloris in MineCraft.
@@ -46,6 +46,10 @@ function _output {
     local _yellow=""
     local _cyan=""
     local _reset=""
+
+    if [ "$_mode" = debug ] && [ "$_debug" != true ]; then
+        return 0
+    fi
 
     case "$_mode" in
     oops|okay) _fd=2 ;;

--- a/Resources/Server/1MB-start.sh
+++ b/Resources/Server/1MB-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @Filename: 1MB-start.sh
-# @Version: 2.17.3, build 076 for Minecraft 26.2 (Java 25, 64bit)
+# @Version: 2.17.4, build 077 for Minecraft 26.2 (Java 25, 64bit)
 # @Release: August 4th, 2026
 # @Description: Helps us start and fork a Minecraft 26.2 server session.
 # @Contact: I am @floris on Twitter, and mrfloris in MineCraft.
@@ -32,8 +32,6 @@ _serverName="mcserver"
 _sibling="1MB-minecraft.sh"
 _debug=true # Set to false to minimize output.
 
-Y="\\033[33m"; C="\\033[36m"; R="\\033[0m" # theme
-
 ### FUNCTIONS AND CODE
 #
 # ! WE ARE DONE, STOP EDITING BEYOND THIS POINT !
@@ -41,22 +39,40 @@ Y="\\033[33m"; C="\\033[36m"; R="\\033[0m" # theme
 ###
 
 function _output {
-    case "$1" in
+    local _mode="${1:-}"
+    local _args=""
+    local _prefix=""
+    local _fd=1
+    local _yellow=""
+    local _cyan=""
+    local _reset=""
+
+    case "$_mode" in
+    oops|okay) _fd=2 ;;
+    esac
+
+    if [ -z "${NO_COLOR+x}" ] && [ -t "$_fd" ]; then
+        printf -v _yellow '\033[33m'
+        printf -v _cyan '\033[36m'
+        printf -v _reset '\033[0m'
+    fi
+
+    case "$_mode" in
     oops)
         _args="${*:2}"; _prefix="(Script Halted!)";
-        echo -e "\\n$B$Y$_prefix$X $_args $R" >&2; exit 1
+        printf '\n%s%s %s%s\n' "$_yellow" "$_prefix" "$_args" "$_reset" >&2; exit 1
     ;;
     okay)
         _args="${*:2}"; _prefix="(Info)";
-        echo -e "\\n$B$Y$_prefix$C $_args $R" >&2; exit 1
+        printf '\n%s%s%s %s%s\n' "$_yellow" "$_prefix" "$_cyan" "$_args" "$_reset" >&2; exit 1
     ;;
     debug)
         _args="${*:2}"; _prefix="(Debug)";
-        [[ "$_debug" == true ]] && echo -e "$Y$_prefix$C $_args $R"
+        [[ "$_debug" == true ]] && printf '%s%s%s %s%s\n' "$_yellow" "$_prefix" "$_cyan" "$_args" "$_reset"
     ;;
     *)
         _args="${*:1}"; _prefix="(Info)";
-        echo -e "\\n$_prefix $_args"
+        printf '\n%s %s\n' "$_prefix" "$_args"
     ;;
     esac
 }

--- a/Resources/Server/1MB-start.sh
+++ b/Resources/Server/1MB-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @Filename: 1MB-start.sh
-# @Version: 2.17.5, build 078 for Minecraft 26.2 (Java 25, 64bit)
+# @Version: 2.17.6, build 079 for Minecraft 26.2 (Java 25, 64bit)
 # @Release: August 4th, 2026
 # @Description: Helps us start and fork a Minecraft 26.2 server session.
 # @Contact: I am @floris on Twitter, and mrfloris in MineCraft.
@@ -146,6 +146,6 @@ if ! tmux new-session -d -s "$_serverName" -c "$_scriptDir" "exec \"./$_sibling\
 fi
 [[ "$_debug" == true ]] && tmux ls; _output debug "To re-attach: tmux attach -t $_serverName"
 
-_output debug "Done."
+_output debug "tmux session started."
 
 #EOF Copyright (c) 1977-2026 - Floris Fiedeldij Dop - https://scripts.1moreblock.com

--- a/Resources/Server/1MB-start.sh
+++ b/Resources/Server/1MB-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @Filename: 1MB-start.sh
-# @Version: 2.17.7, build 080 for Minecraft 26.2 (Java 25, 64bit)
+# @Version: 2.17.8, build 081 for Minecraft 26.2 (Java 25, 64bit)
 # @Release: August 4th, 2026
 # @Description: Helps us start and fork a Minecraft 26.2 server session.
 # @Contact: I am @floris on Twitter, and mrfloris in MineCraft.
@@ -125,7 +125,7 @@ if [ -L "$_siblingPath" ] || [ ! -f "$_siblingPath" ] || [ ! -r "$_siblingPath" 
 fi
 
 if [ -n "$1" ]; then
-    _input=$(echo "$1" | awk '{ print tolower($1) }'); _input=$(echo "${_input}" | awk '{print substr ($0, 0, 16)}');
+    _input=$(echo "$1" | awk '{ print tolower($1) }'); _input=$(echo "${_input}" | awk '{print substr ($0, 1, 16)}');
     if [[ "$_input" =~ ^[a-z]+$ ]]; then
         _serverName="$_input"
     else

--- a/Resources/Server/1MB-start.sh
+++ b/Resources/Server/1MB-start.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 # @Filename: 1MB-start.sh
-# @Version: 2.17.8, build 081 for Minecraft 26.2 (Java 25, 64bit)
+# @Version: 2.17.9, build 082 for Minecraft 26.2 (Java 25, 64bit)
 # @Release: August 4th, 2026
 # @Description: Helps us start and fork a Minecraft 26.2 server session.
 # @Contact: I am @floris on Twitter, and mrfloris in MineCraft.
 # @Discord: @mrfloris on https://discord.gg/floris
 # @Install: chmod +x 1MB-start.sh
-# @Syntax: ./1MB-start.sh (name)
+# @Syntax: ./1MB-start.sh [name] (see --help for commands)
 # @URL: Latest source, wiki, & support: https://scripts.1moreblock.com/
 
 ### CONFIGURATION
@@ -115,30 +115,102 @@ function _resolveScriptDirectory {
     cd -P -- "$(dirname -- "$_source")" >/dev/null 2>&1 && pwd -P
 }
 
+function _showHelp {
+    local _programName="${0##*/}"
+
+    printf '%s\n' \
+        "Usage:" \
+        "  $_programName [name]" \
+        "  $_programName --status [name]" \
+        "  $_programName --attach [name]" \
+        "  $_programName --help" \
+        "" \
+        "Commands:" \
+        "  (none)           Start the adjacent $_sibling in detached tmux." \
+        "  --status [name]  Report whether the exact tmux session exists." \
+        "  --attach [name]  Attach to the exact tmux session." \
+        "  --help, -h       Show this help." \
+        "" \
+        "The session name defaults to '$_serverName'."
+}
+
+function _setServerName {
+    local _requestedName="${1:-}"
+    local _input=""
+
+    if [ -n "$_requestedName" ]; then
+        _input=$(printf '%s\n' "$_requestedName" | awk '{ print tolower($1) }')
+        _input=$(printf '%s\n' "$_input" | awk '{ print substr($0, 1, 16) }')
+
+        if [[ "$_input" =~ ^[a-z]+$ ]]; then
+            _serverName="$_input"
+        else
+            _output oops "Provided input is invalid! Input is for a unique '_serverName'. Do not use numbers, spaces or weird chars. Keep it short, and a-z characters only."
+        fi
+    fi
+}
+
+_action="start"
+_nameArgument="${1:-}"
+
+case "${1:-}" in
+-h|--help)
+    _showHelp
+    exit 0
+    ;;
+--status)
+    _action="status"
+    _nameArgument="${2:-}"
+    ;;
+--attach)
+    _action="attach"
+    _nameArgument="${2:-}"
+    ;;
+--*)
+    _output oops "Unknown option '$1'. Run '$0 --help' for usage."
+    ;;
+esac
+
 [ "$EUID" -eq 0 ] && _output oops "*!* This script should not be run using sudo, or as the root user!"
 
-_scriptDir=$(_resolveScriptDirectory) || _output oops "Could not resolve the server directory containing '$0'."
-_siblingPath="$_scriptDir/$_sibling"
+if [ "$_action" = start ]; then
+    _scriptDir=$(_resolveScriptDirectory) || _output oops "Could not resolve the server directory containing '$0'."
+    _siblingPath="$_scriptDir/$_sibling"
 
-if [ -L "$_siblingPath" ] || [ ! -f "$_siblingPath" ] || [ ! -r "$_siblingPath" ] || [ ! -x "$_siblingPath" ]; then
-    _output oops "'$_sibling' must be a regular, non-symlink, readable and executable file beside this wrapper: '$_siblingPath'. Files elsewhere are not used. Correct the file, or download it from https://scripts.1moreblock.com/ "
-fi
-
-if [ -n "$1" ]; then
-    _input=$(echo "$1" | awk '{ print tolower($1) }'); _input=$(echo "${_input}" | awk '{print substr ($0, 1, 16)}');
-    if [[ "$_input" =~ ^[a-z]+$ ]]; then
-        _serverName="$_input"
-    else
-        _output oops "Provided input is invalid! Input is for a unique '_serverName'. Do not use numbers, spaces or weird chars. Keep it short, and a-z characters only."
+    if [ -L "$_siblingPath" ] || [ ! -f "$_siblingPath" ] || [ ! -r "$_siblingPath" ] || [ ! -x "$_siblingPath" ]; then
+        _output oops "'$_sibling' must be a regular, non-symlink, readable and executable file beside this wrapper: '$_siblingPath'. Files elsewhere are not used. Correct the file, or download it from https://scripts.1moreblock.com/ "
     fi
 fi
 
-_output debug "Attempting to start your Minecraft '$_serverName' server ... "
-_output debug "Using server directory: $_scriptDir"
+_setServerName "$_nameArgument"
 
 if ! type "tmux" >/dev/null 2>&1; then
     _output oops "'tmux' is required but was not found. On macOS, install it with: brew install tmux"
 fi
+
+case "$_action" in
+status)
+    if tmux has-session -t "=$_serverName" 2>/dev/null; then
+        _output "tmux session '$_serverName' is running."
+        exit 0
+    fi
+
+    _output "tmux session '$_serverName' is not running."
+    exit 1
+    ;;
+attach)
+    if ! tmux has-session -t "=$_serverName" 2>/dev/null; then
+        _output oops "No tmux session named '$_serverName' is running."
+    fi
+
+    _output debug "Attaching to tmux session '$_serverName' ..."
+    exec tmux attach-session -t "=$_serverName"
+    _output oops "Could not execute tmux attach-session for '$_serverName'."
+    ;;
+esac
+
+_output debug "Attempting to start your Minecraft '$_serverName' server ... "
+_output debug "Using server directory: $_scriptDir"
 
 _output debug "Found 'tmux', attempting to start '$_sibling' in a detached tmux session ..."
 # Deliberately launch only ./1MB-minecraft.sh from the wrapper's own directory.

--- a/Resources/Server/1MB-start.sh
+++ b/Resources/Server/1MB-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @Filename: 1MB-start.sh
-# @Version: 2.17.6, build 079 for Minecraft 26.2 (Java 25, 64bit)
+# @Version: 2.17.7, build 080 for Minecraft 26.2 (Java 25, 64bit)
 # @Release: August 4th, 2026
 # @Description: Helps us start and fork a Minecraft 26.2 server session.
 # @Contact: I am @floris on Twitter, and mrfloris in MineCraft.
@@ -120,8 +120,8 @@ function _resolveScriptDirectory {
 _scriptDir=$(_resolveScriptDirectory) || _output oops "Could not resolve the server directory containing '$0'."
 _siblingPath="$_scriptDir/$_sibling"
 
-if [ ! -f "$_siblingPath" ] || [ ! -r "$_siblingPath" ] || [ ! -x "$_siblingPath" ]; then
-    _output oops "This '$0' script requires '$_siblingPath' to be a readable and executable file. Correct the permissions, or download it from https://scripts.1moreblock.com/ "
+if [ -L "$_siblingPath" ] || [ ! -f "$_siblingPath" ] || [ ! -r "$_siblingPath" ] || [ ! -x "$_siblingPath" ]; then
+    _output oops "'$_sibling' must be a regular, non-symlink, readable and executable file beside this wrapper: '$_siblingPath'. Files elsewhere are not used. Correct the file, or download it from https://scripts.1moreblock.com/ "
 fi
 
 if [ -n "$1" ]; then
@@ -141,6 +141,7 @@ if ! type "tmux" >/dev/null 2>&1; then
 fi
 
 _output debug "Found 'tmux', attempting to start '$_sibling' in a detached tmux session ..."
+# Deliberately launch only ./1MB-minecraft.sh from the wrapper's own directory.
 if ! tmux new-session -d -s "$_serverName" -c "$_scriptDir" "exec \"./$_sibling\""; then
     _output oops "Could not create the '$_serverName' tmux session and start '$_sibling'. Review the tmux error above and check with 'tmux ls'."
 fi

--- a/Resources/Server/1mb-start-todo.md
+++ b/Resources/Server/1mb-start-todo.md
@@ -82,6 +82,14 @@ scoped fix. The file's missing final newline was normalized mechanically.
   of implying that Paper completed startup. The wrapper can confirm tmux's
   result, but it cannot confirm that Paper reached its ready state.
 
+## Completed in 2.17.7 build 080
+
+- [x] Require `1MB-minecraft.sh` to be a regular, non-symlink, readable and
+  executable file physically located beside the resolved `1MB-start.sh`.
+- [x] Continue launching that exact sibling through `./1MB-minecraft.sh` with
+  tmux's working directory fixed to the wrapper directory. The caller's current
+  directory, `PATH`, other directories, and other volumes are not searched.
+
 ## Critical
 
 - [x] Stop immediately when tmux session creation fails; never send startup
@@ -93,6 +101,9 @@ scoped fix. The file's missing final newline was normalized mechanically.
   the caller's current working directory. Completed in `2.17.3`, build `076`,
   including launchd, systemd, SSH, PATH, absolute-path, and symlinked
   invocation scenarios.
+- [x] Reject a symlinked `1MB-minecraft.sh`, preventing the adjacent filename
+  from redirecting execution to a file in another location. Completed in
+  `2.17.7`, build `080`.
 - [x] Replace the two-stage `tmux new` plus `tmux send-keys` launch with one
   checked, atomic `tmux new-session -d` command that starts the sibling
   directly. Completed in `2.17.2`, build `075`.

--- a/Resources/Server/1mb-start-todo.md
+++ b/Resources/Server/1mb-start-todo.md
@@ -76,6 +76,12 @@ scoped fix. The file's missing final newline was normalized mechanically.
 - [x] Real startup failures remain nonzero and continue through their existing
   error paths when debug output is disabled.
 
+## Completed in 2.17.6 build 079
+
+- [x] Report `tmux session started.` after successful session creation instead
+  of implying that Paper completed startup. The wrapper can confirm tmux's
+  result, but it cannot confirm that Paper reached its ready state.
+
 ## Critical
 
 - [x] Stop immediately when tmux session creation fails; never send startup

--- a/Resources/Server/1mb-start-todo.md
+++ b/Resources/Server/1mb-start-todo.md
@@ -59,6 +59,15 @@ scoped fix. The file's missing final newline was normalized mechanically.
 - [x] Give tmux the resolved server directory explicitly with `new-session -c`
   and validate the sibling through its resolved absolute path.
 
+## Completed in 2.17.4 build 077
+
+- [x] Replaced `echo -e` with Bash's built-in `printf` using fixed format
+  strings and `%s` message arguments.
+- [x] Emit ANSI colours only when the actual output destination is a terminal
+  and `NO_COLOR` is not set. Stdout and stderr are checked independently.
+- [x] Made output-function state local and removed the undefined `B` and `X`
+  colour variables.
+
 ## Critical
 
 - [x] Stop immediately when tmux session creation fails; never send startup
@@ -104,12 +113,14 @@ scoped fix. The file's missing final newline was normalized mechanically.
 
 ## Low priority and cleanup
 
-- [ ] Replace `echo -e` with Bash's built-in `printf`.
-- [ ] Make output-function variables local, initialize or remove the undefined
-  `B` and `X` color variables, and correct the `okay` branch so it does not exit
+- [x] Replace `echo -e` with Bash's built-in `printf`. Completed in `2.17.4`,
+  build `077`.
+- [x] Make output-function variables local and remove the undefined `B` and `X`
+  colour variables. Completed in `2.17.4`, build `077`.
+- [ ] Correct the `okay` branch so a successful status message does not exit
   with status `1`.
-- [ ] Emit ANSI colors only to an interactive terminal and honor `NO_COLOR` so
-  launchd/systemd logs remain clean.
+- [x] Emit ANSI colours only to an interactive terminal and honor `NO_COLOR`
+  so launchd/systemd logs remain clean. Completed in `2.17.4`, build `077`.
 - [x] Verify that the sibling is a regular readable and executable file, and
   include its absolute path in errors. Completed in `2.17.3`, build `076`.
 - [x] Remove the obsolete Screen and Ubuntu dependency hints. Completed in

--- a/Resources/Server/1mb-start-todo.md
+++ b/Resources/Server/1mb-start-todo.md
@@ -68,6 +68,14 @@ scoped fix. The file's missing final newline was normalized mechanically.
 - [x] Made output-function state local and removed the undefined `B` and `X`
   colour variables.
 
+## Completed in 2.17.5 build 078
+
+- [x] Disabled debug messages now return success without producing output, so
+  `_debug=false` no longer turns an otherwise successful wrapper run into exit
+  status `1`.
+- [x] Real startup failures remain nonzero and continue through their existing
+  error paths when debug output is disabled.
+
 ## Critical
 
 - [x] Stop immediately when tmux session creation fails; never send startup
@@ -85,9 +93,9 @@ scoped fix. The file's missing final newline was normalized mechanically.
 - [ ] Detect and report when the child exits immediately after tmux successfully
   creates the session. The tmux command confirms session creation, not that
   Paper completed startup.
-- [ ] Fix `_debug=false`: the final debug call currently returns status `1`, so
-  an otherwise successful wrapper exits as a failure when debug output is
-  disabled.
+- [x] Fix `_debug=false`: disabled debug messages now return success, so an
+  otherwise successful wrapper exits successfully. Completed in `2.17.5`,
+  build `078`.
 - [x] Remove the implicit GNU Screen fallback. Completed in `2.17.1`, build
   `074`; tmux is now required.
 - [ ] Add a per-server-instance lock in `1MB-minecraft.sh` during that script's

--- a/Resources/Server/1mb-start-todo.md
+++ b/Resources/Server/1mb-start-todo.md
@@ -100,6 +100,17 @@ scoped fix. The file's missing final newline was normalized mechanically.
   POSIX-defined `1`, preserving the existing 16-character truncation on both
   macOS and Ubuntu.
 
+## Completed in 2.17.9 build 082
+
+- [x] Added `--help` (`-h`) with concise usage that works without tmux or an
+  adjacent `1MB-minecraft.sh`.
+- [x] Added `--status [name]`, using an exact tmux session target and exit
+  status `0` for running or `1` for not running.
+- [x] Added `--attach [name]`, which checks the exact session and then replaces
+  the wrapper with `tmux attach-session` so tmux's exit status is preserved.
+- [x] Kept sibling resolution and validation exclusive to normal startup, so
+  existing sessions remain inspectable when the sibling file is unavailable.
+
 ## Critical
 
 - [x] Stop immediately when tmux session creation fails; never send startup
@@ -175,8 +186,8 @@ scoped fix. The file's missing final newline was normalized mechanically.
 - [ ] Introduce a `main "$@"` function and explicit checked error paths. Review
   all helper return statuses before considering `set -e`; `set -u` and
   `set -o pipefail` can then be evaluated safely.
-- [ ] Add optional `--help`, `--version`, `--status`, and `--attach` commands
-  only if their added complexity is worthwhile.
+- [x] Add small `--help`, `--status`, and `--attach` commands. Completed in
+  `2.17.9`, build `082`; `--version` was intentionally not added.
 - [ ] Add repeatable checks with `bash -n`, ShellCheck, and disposable fake or
   isolated tmux sessions for success, duplicate-name, missing-sibling, and
   missing-dependency paths.

--- a/Resources/Server/1mb-start-todo.md
+++ b/Resources/Server/1mb-start-todo.md
@@ -90,6 +90,16 @@ scoped fix. The file's missing final newline was normalized mechanically.
   tmux's working directory fixed to the wrapper directory. The caller's current
   directory, `PATH`, other directories, and other volumes are not searched.
 
+## Completed in 2.17.8 build 081
+
+- [x] Audited the complete wrapper against macOS's stock Bash `3.2.57` and
+  verified that it contains no Bash 4+ constructs.
+- [x] Retained Bash 3.2-compatible implementations for case conversion,
+  indexed `BASH_SOURCE`, output handling, symlink resolution, and conditionals.
+- [x] Changed awk's substring start index from implementation-tolerated `0` to
+  POSIX-defined `1`, preserving the existing 16-character truncation on both
+  macOS and Ubuntu.
+
 ## Critical
 
 - [x] Stop immediately when tmux session creation fails; never send startup
@@ -159,9 +169,9 @@ scoped fix. The file's missing final newline was normalized mechanically.
 
 ## Bash hardening and quality of life
 
-- [ ] Keep compatibility with the stock macOS Bash 3.2 and current Ubuntu
+- [x] Keep compatibility with the stock macOS Bash 3.2 and current Ubuntu
   Bash. Avoid Bash 4-only lowercase expansion, associative arrays, `mapfile`,
-  GNU `flock`, and `readlink -f`.
+  GNU `flock`, and `readlink -f`. Audited and tested in `2.17.8`, build `081`.
 - [ ] Introduce a `main "$@"` function and explicit checked error paths. Review
   all helper return statuses before considering `set -e`; `set -u` and
   `set -o pipefail` can then be evaluated safely.


### PR DESCRIPTION
## What changed

- replace `echo -e` output handling with Bash `printf`
- emit ANSI colours only for terminal output and honor `NO_COLOR`
- make disabled debug output return success
- report successful tmux session creation without implying Paper is ready
- require the adjacent `1MB-minecraft.sh` to be a regular, readable,
  executable, non-symlink file
- verify compatibility with macOS Bash 3.2 and current Bash
- add small `--help`, `--status [name]`, and `--attach [name]` conveniences
- update the launcher modernization TODO with completed work

## Why

The wrapper should have reliable exit statuses and clean output in terminals,
logs, launchd, and systemd. It must launch only the intended sibling script,
describe only the state it can actually verify, and remain usable with the
stock Bash included with macOS.

## Impact

Normal `./1MB-start.sh [name]` startup remains compatible. Operators gain exact
tmux status and attach commands. A symlinked sibling is now rejected
intentionally so the wrapper cannot redirect execution elsewhere.

## Validation

- `bash -n` with macOS Bash 3.2.57
- `bash -n` with Bash 5.3.15
- success and failure launch simulations with fake tmux
- debug enabled/disabled exit-status checks
- regular, unreadable, non-executable, directory, and symlink sibling checks
- exact tmux target test against an isolated real tmux server
- `git diff --check`
